### PR TITLE
Rename reschedule action to Pause and clarify skip messaging

### DIFF
--- a/snippets/recharge-footer.liquid
+++ b/snippets/recharge-footer.liquid
@@ -728,15 +728,20 @@
       productsAvailableForPurchaseManagerNew.init();
       
       let intervalId = setInterval(function () {
-        if ($('.recharge-component-schedule-item .recharge-card > div > div:last-child > div > div:last-child > div > div:last-child').length && $('.recharge-component-schedule-item .recharge-alert').length == 0) {
+        if ($('[data-testid="recharge-internal-skip-button"]').length && $('.recharge-component-schedule-item .recharge-alert').length == 0) {
+          const rescheduleBtn = $('[data-testid="recharge-internal-reschedule-button"]');
+          if (rescheduleBtn.length) {
+            rescheduleBtn.find('span').text('Pause');
+          }
           if ($('.yno-cancel').length == 0) {
-            $('.recharge-component-schedule-item .recharge-card > div > div:last-child > div > div:last-child > div > div:last-child').append(`
+            const skipParent = $('[data-testid="recharge-internal-skip-button"]').parent().parent();
+            skipParent.after(`
               <button class="yno-cancel">
                 <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" width="16" height="16"><g stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><path d="M1.143 4h13.714M2.857 4h10.286v10.286A1.143 1.143 0 0 1 12 15.429H4a1.143 1.143 0 0 1-1.143-1.143V4ZM5.143 4v-.571a2.857 2.857 0 0 1 5.714 0V4M6.286 7.43v4.573M9.714 7.43v4.573"></path></g></svg>
                 <span>Cancel</span>
               </button>
             `);
-            $('.recharge-component-schedule-item .recharge-card > div > div:last-child > div > div:last-child > div > div:first-child').append(`
+            $('[data-testid="recharge-internal-skip-button"]').parent().prepend(`
               <span class="yno-label">Cancel subscription</span>
             `);
             $('body').append(`
@@ -1013,6 +1018,16 @@
         }
       }, 100);
     }
+  });
+
+  $(document).on('click', '[data-testid="recharge-internal-skip-button"]', function () {
+    const popupInterval = setInterval(() => {
+      const messageEl = $("body").find("p:contains('skip this order')");
+      if (messageEl.length) {
+        messageEl.text("If you skip this month's order, your next shipment will be sent in 28 days\u2014on your next scheduled delivery date.");
+        clearInterval(popupInterval);
+      }
+    }, 100);
   });
 
   $(document).on('click', '.build-box .recharge-heading', function () {


### PR DESCRIPTION
## Summary
- Replace Reschedule with Pause in subscription actions and add adjacent Cancel button
- Clarify skip order popup text with next shipment details

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896d2a4cb2483329d93af96798ee8c2