### PR TITLE
Rename reschedule action to Pause and refine cancel handling

### DIFF
--- a/snippets/recharge-footer.liquid
+++ b/snippets/recharge-footer.liquid
@@ -728,17 +728,22 @@
       productsAvailableForPurchaseManagerNew.init();
       
       let intervalId = setInterval(function () {
-        if ($('.recharge-component-schedule-item .recharge-card > div > div:last-child > div > div:last-child > div > div:last-child').length && $('.recharge-component-schedule-item .recharge-alert').length == 0) {
+        if ($('[data-testid="recharge-internal-skip-button"]').length && $('.recharge-component-schedule-item .recharge-alert').length == 0) {
+          const rescheduleBtn = $('[data-testid="recharge-internal-reschedule-button"]');
+          if (rescheduleBtn.length) {
+            rescheduleBtn.find('span').text('Pause');
+          }
           if ($('.yno-cancel').length == 0) {
-            $('.recharge-component-schedule-item .recharge-card > div > div:last-child > div > div:last-child > div > div:last-child').append(`
-              <button class="yno-cancel">
-                <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" width="16" height="16"><g stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><path d="M1.143 4h13.714M2.857 4h10.286v10.286A1.143 1.143 0 0 1 12 15.429H4a1.143 1.143 0 0 1-1.143-1.143V4ZM5.143 4v-.571a2.857 2.857 0 0 1 5.714 0V4M6.286 7.43v4.573M9.714 7.43v4.573"></path></g></svg>
-                <span>Cancel</span>
-              </button>
+            const skipBtn = $('[data-testid="recharge-internal-skip-button"]');
+            const cancelBtn = skipBtn.clone();
+            cancelBtn.attr('data-testid', 'recharge-internal-cancel-button');
+            cancelBtn.addClass('yno-cancel');
+            cancelBtn.find('span').text('Cancel');
+            cancelBtn.css('margin-left', '20px');
+            cancelBtn.find('.recharge-icon').html(`
+              <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" width="16" height="16"><g stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><path d="M1.143 4h13.714M2.857 4h10.286v10.286A1.143 1.143 0 0 1 12 15.429H4a1.143 1.143 0 0 1-1.143-1.143V4ZM5.143 4v-.571a2.857 2.857 0 0 1 5.714 0V4M6.286 7.43v4.573M9.714 7.43v4.573"></path></g></svg>
             `);
-            $('.recharge-component-schedule-item .recharge-card > div > div:last-child > div > div:last-child > div > div:first-child').append(`
-              <span class="yno-label">Cancel subscription</span>
-            `);
+            skipBtn.after(cancelBtn);
             $('body').append(`
               <div class="cancel-popup">
                 <div class="cancel-popup__overlay"></div>

--- a/snippets/recharge-header.liquid
+++ b/snippets/recharge-header.liquid
@@ -110,36 +110,6 @@
   .recharge-section-next-order-actions .recharge-card {
     position: relative;
   }
-  .yno-cancel {
-    color: var(--recharge-button-secondary);
-    position: static;
-    right: 25px;
-    top: 22px;
-    font-size: 16px;
-    display: flex;
-    align-items: center;
-    gap: 7px;
-    text-align: right;
-    justify-content: flex-end;
-    /* margin: 30px auto; */
-    padding: 0;
-    width: 100%;
-    margin-top: 5px;
-  }
-  .yno-label {
-    display: block;
-    font-size: var(--recharge-typography-size-5);
-    line-height: 150%;
-    font-weight: var(--recharge-typography-body-font-weight);
-  }
-  @media (max-width: 768px) {
-    .yno-label {
-      display: none;
-    }
-  }
-  .yno-cancel span {
-    font-weight: 500;
-  }
   .cancel-popup {
     position: fixed;
     top: 0;
@@ -331,12 +301,6 @@
     }
     .cancel-popup {
       align-items: flex-end;
-    }
-    .yno-cancel {
-      font-size: 16px;
-      justify-content: flex-start;
-      margin-left: 4px;
-      gap: 10px;
     }
   }
 


### PR DESCRIPTION
## Summary
- Convert Reschedule to Pause and clone Skip button to render a matching Cancel action
- Remove stray Cancel Subscription label and obsolete skip popup text override
- Drop custom cancel/label styles so buttons share default sizing
- Add 20px margin to space Skip and Cancel buttons apart

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896d2a4cb2483329d93af96798ee8c2