### PR TITLE
feat: add multi-stage survivor quiz

### DIFF
--- a/sections/cancer-question.liquid
+++ b/sections/cancer-question.liquid
@@ -10,17 +10,28 @@
           <p>{{ section.settings.subheading }}</p>
         </div>
         <div class="cancer-question__blocks">
-          {% for block in section.blocks %}
-            <div class="cancer-question__block" data-url="{{ block.settings.product.url }}">
-              <div class="cancer-question__block-content">
-                <div class="cancer-question__block-icon"></div>
-                <div class="cancer-question__block-text">
-                  <p class="cancer-question__block-text--title">{{ block.settings.title }}</p>
-                  <p class="cancer-question__block-text--desc">{{ block.settings.description }}</p>
+          {%- assign current_stage = '' -%}
+          {%- for block in section.blocks -%}
+            {%- if block.type == 'option' -%}
+              {%- assign block_stage = block.settings.stage | append: '' -%}
+              {%- if current_stage != block_stage -%}
+                {%- unless current_stage == '' -%}</div>{%- endunless -%}
+                <div class="cancer-question__stage" data-stage="{{ block_stage }}"{%- unless current_stage == '' -%} style="display:none"{%- endunless -%}>
+                  <p class="cancer-question__question-text">{{ block.settings.question }}</p>
+                {%- assign current_stage = block_stage -%}
+              {%- endif -%}
+              <div class="cancer-question__block" data-stage="{{ block.settings.stage }}" data-value="{{ block.settings.value }}">
+                <div class="cancer-question__block-content">
+                  <div class="cancer-question__block-icon"></div>
+                  <div class="cancer-question__block-text">
+                    <p class="cancer-question__block-text--title">{{ block.settings.title }}</p>
+                    <p class="cancer-question__block-text--desc">{{ block.settings.description }}</p>
+                  </div>
                 </div>
               </div>
-            </div>
-          {% endfor %}
+            {%- endif -%}
+          {%- endfor -%}
+          {%- if current_stage != '' -%}</div>{%- endif -%}
           <!-- New answer option with link to quiz -->
           <div class="cancer-question__block" data-url="/pages/quiz">
             <div class="cancer-question__block-content">
@@ -46,13 +57,22 @@
     display: flex;
   }
 
+  .cancer-question__stage {
+    width: 100%;
+  }
+
+  .cancer-question__question-text {
+    font-weight: bold;
+    margin-bottom: 15px;
+  }
+
   .cancer-question__block {
     cursor: pointer;
     display: flex;
     align-items: center;
     padding: 20px;
     border: 2px solid #ccc;
-    border-radius: 20px; 
+    border-radius: 20px;
     margin-bottom: 20px;
     background-color: #fff;
     width: 100%;
@@ -85,12 +105,12 @@
 
   .cancer-question__block-text--title {
     font-weight: bold;
-    font-size: 16px; 
+    font-size: 16px;
   }
 
   .cancer-question__block-text--desc {
     color: #666;
-    font-size: 14px; 
+    font-size: 14px;
   }
 
   .quiz-button {
@@ -99,11 +119,40 @@
 </style>
 
 <script>
-  $(document).on('click', '.cancer-question__block', function() {
-    $('.cancer-question__block').removeClass('active');
-    $(this).addClass('active');
-    var url = $(this).data('url');
-    window.location.href = url;
+  document.addEventListener('DOMContentLoaded', function() {
+    var answers = {};
+    var totalStages = document.querySelectorAll('.cancer-question__stage').length;
+
+    var resultMap = {
+      {%- assign result_blocks = section.blocks | where: 'type', 'result' -%}
+      {%- for block in result_blocks -%}
+        "{{ block.settings.combination }}": "{{ block.settings.product.url }}"{%- unless forloop.last -%},{%- endunless -%}
+      {%- endfor -%}
+    };
+
+    document.addEventListener('click', function(e) {
+      var target = e.target.closest('.cancer-question__block');
+      if (!target) return;
+      var url = target.getAttribute('data-url');
+      if (url) {
+        window.location.href = url;
+        return;
+      }
+      var stage = parseInt(target.getAttribute('data-stage'));
+      var value = target.getAttribute('data-value');
+      answers[stage] = value;
+      var nextStage = stage + 1;
+      if (nextStage <= totalStages) {
+        document.querySelectorAll('.cancer-question__stage').forEach(function(el) { el.style.display = 'none'; });
+        var next = document.querySelector('.cancer-question__stage[data-stage="' + nextStage + '"]');
+        if (next) { next.style.display = 'block'; }
+      } else {
+        var keyParts = [];
+        for (var i = 1; i <= totalStages; i++) { keyParts.push(answers[i]); }
+        var finalUrl = resultMap[keyParts.join('|')];
+        if (finalUrl) { window.location.href = finalUrl; }
+      }
+    });
   });
 </script>
 
@@ -134,13 +183,23 @@
   ],
   "blocks": [
     {
-      "type": "question",
-      "name": "Question",
+      "type": "option",
+      "name": "Question Option",
       "settings": [
         {
-          "type": "product",
-          "id": "product",
-          "label": "Product"
+          "type": "number",
+          "id": "stage",
+          "label": "Stage Number"
+        },
+        {
+          "type": "text",
+          "id": "question",
+          "label": "Question"
+        },
+        {
+          "type": "text",
+          "id": "value",
+          "label": "Answer Value"
         },
         {
           "type": "text",
@@ -151,6 +210,22 @@
           "type": "textarea",
           "id": "description",
           "label": "Description"
+        }
+      ]
+    },
+    {
+      "type": "result",
+      "name": "Result Mapping",
+      "settings": [
+        {
+          "type": "text",
+          "id": "combination",
+          "label": "Answer Combination (value1|value2|...)"
+        },
+        {
+          "type": "product",
+          "id": "product",
+          "label": "Product"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- support sequential quiz stages for survivor questions
- map answer combinations to products via new result blocks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896e3693d0c833289170258bc7513ea