### PR TITLE
Style Recharge account action buttons

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -8273,3 +8273,35 @@ ul.blog-search-nav li a:hover {
     width: 15px;
     height: 15px;
 }
+
+/* ReCharge account button sizing */
+.recharge-component-schedule-item [data-testid="recharge-internal-skip-button"],
+.recharge-component-schedule-item [data-testid="recharge-internal-send-now-button"],
+.recharge-component-schedule-item [data-testid="recharge-internal-sendnow-button"],
+.recharge-component-schedule-item [data-testid="recharge-internal-reschedule-button"] {
+    padding: 8px 14px;
+    min-width: 110px;
+}
+
+.recharge-component-schedule-item [data-testid="recharge-internal-cancel-button"] {
+    padding: 8px 14px;
+    min-width: 90px;
+    margin-left: 12px !important;
+}
+
+@media (max-width: 749px) {
+    .recharge-component-schedule-item [data-testid="recharge-internal-skip-button"],
+    .recharge-component-schedule-item [data-testid="recharge-internal-send-now-button"],
+    .recharge-component-schedule-item [data-testid="recharge-internal-sendnow-button"],
+    .recharge-component-schedule-item [data-testid="recharge-internal-reschedule-button"],
+    .recharge-component-schedule-item [data-testid="recharge-internal-cancel-button"] {
+        width: 100%;
+        min-width: 0;
+        display: block;
+        margin-left: 0 !important;
+    }
+
+    .recharge-component-schedule-item [data-testid="recharge-internal-cancel-button"] {
+        margin-top: 8px;
+    }
+}


### PR DESCRIPTION
## Summary
- balance Send Now, Skip, Pause button widths in ReCharge account
- make Cancel smaller and stack buttons on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898c706e73c83328c365af64b7df3db