### PR TITLE
Refine Recharge portal action button layout

### DIFF
--- a/snippets/recharge-footer.liquid
+++ b/snippets/recharge-footer.liquid
@@ -739,7 +739,6 @@
             cancelBtn.attr('data-testid', 'recharge-internal-cancel-button');
             cancelBtn.addClass('yno-cancel');
             cancelBtn.find('span').text('Cancel');
-            cancelBtn.css('margin-left', '20px');
             cancelBtn.find('.recharge-icon').html(`
               <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" width="16" height="16"><g stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><path d="M1.143 4h13.714M2.857 4h10.286v10.286A1.143 1.143 0 0 1 12 15.429H4a1.143 1.143 0 0 1-1.143-1.143V4ZM5.143 4v-.571a2.857 2.857 0 0 1 5.714 0V4M6.286 7.43v4.573M9.714 7.43v4.573"></path></g></svg>
             `);

--- a/snippets/recharge-header.liquid
+++ b/snippets/recharge-header.liquid
@@ -109,6 +109,33 @@
   /* Main portal - Cancel subscription */
   .recharge-section-next-order-actions .recharge-card {
     position: relative;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .recharge-section-next-order-actions [data-testid="recharge-internal-send-now-button"],
+  .recharge-section-next-order-actions [data-testid="recharge-internal-reschedule-button"],
+  .recharge-section-next-order-actions [data-testid="recharge-internal-skip-button"] {
+    flex: 1 1 0;
+    padding: 8px 12px;
+    font-size: 14px;
+  }
+  .recharge-section-next-order-actions [data-testid="recharge-internal-cancel-button"] {
+    flex: 0 1 auto;
+    padding: 8px 12px;
+    font-size: 14px;
+  }
+  @media (max-width: 768px) {
+    .recharge-section-next-order-actions .recharge-card {
+      flex-direction: column;
+    }
+    .recharge-section-next-order-actions [data-testid="recharge-internal-send-now-button"],
+    .recharge-section-next-order-actions [data-testid="recharge-internal-reschedule-button"],
+    .recharge-section-next-order-actions [data-testid="recharge-internal-skip-button"],
+    .recharge-section-next-order-actions [data-testid="recharge-internal-cancel-button"] {
+      flex: none;
+      width: 100%;
+    }
   }
   .cancel-popup {
     position: fixed;


### PR DESCRIPTION
## Summary
- equalize Send Now, Pause, and Skip buttons while keeping Cancel compact
- stack next-order action buttons vertically on small screens
- remove inline margin styling from injected Cancel button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898c706e73c83328c365af64b7df3db