### PR TITLE
Style Recharge account action buttons

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -8275,17 +8275,20 @@ ul.blog-search-nav li a:hover {
 }
 
 /* ReCharge account button sizing */
+
 .recharge-component-schedule-item [data-testid="recharge-internal-skip-button"],
 .recharge-component-schedule-item [data-testid="recharge-internal-send-now-button"],
 .recharge-component-schedule-item [data-testid="recharge-internal-sendnow-button"],
 .recharge-component-schedule-item [data-testid="recharge-internal-reschedule-button"] {
     padding: 6px 12px;
-    width: 80px !important;
+    width: 72px !important;
+    flex: 0 0 auto;
 }
 
 .recharge-component-schedule-item [data-testid="recharge-internal-cancel-button"] {
     padding: 6px 12px;
-    width: 60px !important;
+    width: 56px !important;
+    flex: 0 0 auto;
 }
 
 .recharge-component-schedule-item .yno-action-wrap + .yno-action-wrap {
@@ -8295,6 +8298,7 @@ ul.blog-search-nav li a:hover {
 @media (max-width: 749px) {
     .recharge-component-schedule-item .yno-action-wrap {
         width: 100% !important;
+        flex-basis: 100%;
         margin-left: 0 !important;
     }
 
@@ -8306,6 +8310,7 @@ ul.blog-search-nav li a:hover {
         width: 100% !important;
         min-width: 0;
         display: block;
+        flex: 0 0 100%;
     }
 
     .recharge-component-schedule-item [data-testid="recharge-internal-cancel-button"] {

--- a/snippets/recharge-footer.liquid
+++ b/snippets/recharge-footer.liquid
@@ -735,6 +735,12 @@
           }
           if ($('.yno-cancel').length == 0) {
             const skipBtn = $('[data-testid="recharge-internal-skip-button"]');
+            const sendNowBtn = $('[data-testid="recharge-internal-send-now-button"], [data-testid="recharge-internal-sendnow-button"]');
+
+            sendNowBtn.wrap('<div class="yno-action-wrap"></div>');
+            rescheduleBtn.wrap('<div class="yno-action-wrap"></div>');
+            skipBtn.wrap('<div class="yno-action-wrap"></div>');
+
             const cancelBtn = skipBtn.clone();
             cancelBtn.attr('data-testid', 'recharge-internal-cancel-button');
             cancelBtn.addClass('yno-cancel');
@@ -742,11 +748,9 @@
             cancelBtn.find('.recharge-icon').html(`
               <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" width="16" height="16"><g stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><path d="M1.143 4h13.714M2.857 4h10.286v10.286A1.143 1.143 0 0 1 12 15.429H4a1.143 1.143 0 0 1-1.143-1.143V4ZM5.143 4v-.571a2.857 2.857 0 0 1 5.714 0V4M6.286 7.43v4.573M9.714 7.43v4.573"></path></g></svg>
             `);
-            const skipWrapper = skipBtn.parent();
-            skipWrapper.addClass('yno-action-wrap');
-            const cancelWrapper = $('<div></div>').attr('class', skipWrapper.attr('class'));
-            cancelWrapper.append(cancelBtn);
-            skipWrapper.after(cancelWrapper);
+            const cancelWrapper = $('<div class="yno-action-wrap"></div>').append(cancelBtn);
+            skipBtn.closest('.yno-action-wrap').after(cancelWrapper);
+
             $('body').append(`
               <div class="cancel-popup">
                 <div class="cancel-popup__overlay"></div>


### PR DESCRIPTION
## Summary
- balance Send Now, Skip, Pause button widths in ReCharge account
- make Cancel smaller and stack buttons on mobile
- separate Skip and Cancel into individual containers
- shrink desktop buttons and add mobile cancel spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898c706e73c83328c365af64b7df3db