### PR TITLE
Add tabbed FAQ section with accordion questions

### DIFF
--- a/sections/section-faq-tabs.liquid
+++ b/sections/section-faq-tabs.liquid
@@ -1,0 +1,181 @@
+{%- liquid
+  assign bg_color = section.settings.bg_color
+  assign text_color = section.settings.text_color
+  assign animation_anchor = '#FaqTabs--' | append: section.id
+  assign tabs_string = ''
+  for block in section.blocks
+    assign tab = block.settings.tab | strip
+    unless tabs_string contains tab
+      assign tabs_string = tabs_string | append: tab | append: '||'
+    endunless
+  endfor
+  assign tabs_array = tabs_string | split: '||' | compact
+-%}
+
+{%- if section.blocks.size > 0 -%}
+  {%- style -%}
+    #FaqTabs--{{ section.id }} {
+      --PT: {{ section.settings.padding_top }}px;
+      --PB: {{ section.settings.padding_bottom }}px;
+      {%- unless bg_color == 'rgba(0,0,0,0)' or bg_color == blank -%}
+        --bg: {{ bg_color }};
+      {%- endunless -%}
+      {%- unless text_color == 'rgba(0,0,0,0)' or text_color == blank -%}
+        --text: {{ text_color }};
+      {%- endunless -%}
+    }
+  {%- endstyle -%}
+
+  <section id="FaqTabs--{{ section.id }}" class="faq faq--tabs section-padding" data-section-id="{{ section.id }}" data-section-type="faq-tabs" data-aos="hero" data-aos-anchor="{{ animation_anchor }}">
+    <div class="{{ section.settings.width }}">
+      {%- if section.settings.heading != blank -%}
+        <h2 class="faq__title h2" data-aos="hero" data-aos-order="1" data-aos-anchor="{{ animation_anchor }}">{{ section.settings.heading }}</h2>
+      {%- endif -%}
+      <faq-tabs class="faq-tabs" data-tabs-holder>
+        <ul class="faq-tabs__head">
+          {%- for tab in tabs_array -%}
+            <li class="tab-link tab-link-{{ forloop.index0 }}{% if forloop.first %} current{% endif %}" data-tab="{{ forloop.index0 }}" data-block-id="{{ section.id }}-{{ forloop.index0 }}" tabindex="0">
+              <span>{{ tab }}</span>
+            </li>
+          {%- endfor -%}
+        </ul>
+        {%- for tab in tabs_array -%}
+          <div class="tab-content tab-content-{{ forloop.index0 }}{% if forloop.first %} current{% endif %}" data-tab-index="{{ forloop.index0 }}">
+            <div class="faq-list">
+              {%- for block in section.blocks -%}
+                {%- if block.settings.tab == tab -%}
+                  <div class="faq-list__item" {{ block.shopify_attributes }}>
+                    <collapsible-elements>
+                      <details class="accordion" data-collapsible>
+                        <summary class="accordion__title h6" data-collapsible-trigger>
+                          {{ block.settings.question }}
+                          {%- render 'icon-plus' -%}
+                          {%- render 'icon-minus' -%}
+                        </summary>
+                        <div class="accordion__body rte" data-collapsible-body>
+                          <div class="accordion__content" data-collapsible-content>
+                            {{ block.settings.answer }}
+                          </div>
+                        </div>
+                      </details>
+                    </collapsible-elements>
+                  </div>
+                {%- endif -%}
+              {%- endfor -%}
+            </div>
+          </div>
+        {%- endfor -%}
+      </faq-tabs>
+    </div>
+  </section>
+{%- endif -%}
+
+{% schema %}
+{
+  "name": "FAQ tabs",
+  "tag": "section",
+  "class": "section-faq-tabs",
+  "settings": [
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Heading",
+      "default": "FAQs"
+    },
+    {
+      "type": "select",
+      "id": "width",
+      "label": "Layout width",
+      "options": [
+        { "value": "wrapper", "label": "Default" },
+        { "value": "wrapper--narrow", "label": "Narrow" },
+        { "value": "wrapper--full", "label": "Full width" }
+      ],
+      "default": "wrapper"
+    },
+    {
+      "type": "range",
+      "id": "padding_top",
+      "min": 0,
+      "max": 100,
+      "step": 4,
+      "unit": "px",
+      "label": "Padding top",
+      "default": 36
+    },
+    {
+      "type": "range",
+      "id": "padding_bottom",
+      "min": 0,
+      "max": 100,
+      "step": 4,
+      "unit": "px",
+      "label": "Padding bottom",
+      "default": 36
+    },
+    {
+      "type": "color",
+      "id": "bg_color",
+      "label": "Background color",
+      "default": "#ffffff"
+    },
+    {
+      "type": "color",
+      "id": "text_color",
+      "label": "Text color",
+      "default": "#000000"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "faq",
+      "name": "Question",
+      "settings": [
+        { "type": "text", "id": "tab", "label": "Tab title", "default": "General" },
+        { "type": "text", "id": "question", "label": "Question" },
+        { "type": "richtext", "id": "answer", "label": "Answer" }
+      ]
+    }
+  ],
+  "presets": [
+    { "name": "FAQ tabs" }
+  ]
+}
+{% endschema %}
+
+{% stylesheet %}
+/* Add minimal styling for faq tabs */
+.faq-tabs__head {
+  display: flex;
+  gap: 1rem;
+  list-style: none;
+  margin: 0 0 1.5rem 0;
+  padding: 0;
+}
+.tab-link { cursor: pointer; }
+.tab-content { display: none; }
+.tab-content.current { display: block; }
+{% endstylesheet %}
+
+{% javascript %}
+class FaqTabs extends HTMLElement {
+  connectedCallback() {
+    this.querySelectorAll('.tab-link').forEach((link) => {
+      link.addEventListener('click', () => {
+        const index = link.getAttribute('data-tab');
+        this.switchTab(index);
+      });
+    });
+  }
+
+  switchTab(index) {
+    this.querySelectorAll('.tab-link').forEach((link) => {
+      link.classList.toggle('current', link.getAttribute('data-tab') === index);
+    });
+    this.querySelectorAll('.tab-content').forEach((content) => {
+      content.classList.toggle('current', content.getAttribute('data-tab-index') === index);
+    });
+  }
+}
+customElements.define('faq-tabs', FaqTabs);
+{% endjavascript %}


### PR DESCRIPTION
## Summary
- create `section-faq-tabs.liquid` to render FAQs organized by tabs with collapsible answers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68996eb0502c833289c7f8c9f87d6aca