### PR TITLE
Unify Recharge portal action button layout and styling

### DIFF
--- a/snippets/recharge-footer.liquid
+++ b/snippets/recharge-footer.liquid
@@ -735,15 +735,18 @@
           }
           if ($('.yno-cancel').length == 0) {
             const skipBtn = $('[data-testid="recharge-internal-skip-button"]');
+            const skipWrapper = skipBtn.parent();
+            const cancelWrapper = skipWrapper.clone();
+            cancelWrapper.empty();
             const cancelBtn = skipBtn.clone();
             cancelBtn.attr('data-testid', 'recharge-internal-cancel-button');
             cancelBtn.addClass('yno-cancel');
             cancelBtn.find('span').text('Cancel');
-            cancelBtn.css('margin-left', '20px');
             cancelBtn.find('.recharge-icon').html(`
               <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" width="16" height="16"><g stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><path d="M1.143 4h13.714M2.857 4h10.286v10.286A1.143 1.143 0 0 1 12 15.429H4a1.143 1.143 0 0 1-1.143-1.143V4ZM5.143 4v-.571a2.857 2.857 0 0 1 5.714 0V4M6.286 7.43v4.573M9.714 7.43v4.573"></path></g></svg>
             `);
-            skipBtn.after(cancelBtn);
+            cancelWrapper.append(cancelBtn);
+            skipWrapper.after(cancelWrapper);
             $('body').append(`
               <div class="cancel-popup">
                 <div class="cancel-popup__overlay"></div>

--- a/snippets/recharge-header.liquid
+++ b/snippets/recharge-header.liquid
@@ -110,6 +110,34 @@
   .recharge-section-next-order-actions .recharge-card {
     position: relative;
   }
+  .recharge-section-next-order-actions .recharge-card__footer {
+    display: flex;
+    flex-wrap: wrap;
+  }
+  .recharge-section-next-order-actions [data-testid="recharge-internal-charge-button"],
+  .recharge-section-next-order-actions [data-testid="recharge-internal-reschedule-button"],
+  .recharge-section-next-order-actions [data-testid="recharge-internal-skip-button"],
+  .recharge-section-next-order-actions [data-testid="recharge-internal-cancel-button"] {
+    width: 100%;
+    margin: 0 0 10px;
+  }
+  @media (min-width: 769px) {
+    .recharge-section-next-order-actions [data-testid="recharge-internal-charge-button"],
+    .recharge-section-next-order-actions [data-testid="recharge-internal-reschedule-button"],
+    .recharge-section-next-order-actions [data-testid="recharge-internal-skip-button"],
+    .recharge-section-next-order-actions [data-testid="recharge-internal-cancel-button"] {
+      width: 25%;
+      margin: 0;
+    }
+    .recharge-section-next-order-actions .recharge-card__footer {
+      flex-wrap: nowrap;
+    }
+  }
+  .recharge-section-next-order-actions [data-testid="recharge-internal-charge-button"] {
+    background: var(--recharge-button-secondary);
+    border-color: var(--recharge-button-secondary);
+    color: var(--recharge-button-color);
+  }
   .cancel-popup {
     position: fixed;
     top: 0;


### PR DESCRIPTION
## Summary
- Separate cancel button from skip so each sits in its own wrapper
- Add responsive styles to stack buttons on mobile and align on desktop
- Match "Send Now" button color with other action buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ece94d02c8332b0c1a2c0ec7982b2