### PR TITLE
Allow multiple parent answers in cancer quiz

### DIFF
--- a/sections/cancer-question.liquid
+++ b/sections/cancer-question.liquid
@@ -118,6 +118,15 @@
       {% endfor %}
     ];
 
+    // Allow multiple parent answers separated by "|"
+    questionBlocks.forEach(function (q) {
+      if (typeof q.parent === 'string') {
+        q.parent = q.parent.split('|').map(function (p) {
+          return p.trim();
+        }).filter(Boolean);
+      }
+    });
+
     var resultMap = {
       {% assign result_blocks = section.blocks | where: 'type', 'result' %}
       {% for block in result_blocks %}
@@ -134,7 +143,7 @@
       container.innerHTML = '';
 
       var choices = questionBlocks.filter(function (b) {
-        return b.step === step && (step === 1 || b.parent === parentTitle);
+        return b.step === step && (step === 1 || b.parent.includes(parentTitle));
       });
 
       if (!choices.length) {
@@ -221,7 +230,7 @@
       "name": "Answer Option",
       "settings": [
         { "type": "range", "id": "step", "label": "Step Number", "min": 1, "max": 10, "step": 1, "default": 1 },
-        { "type": "text", "id": "parent", "label": "Parent Answer Title (leave blank for step 1)" },
+        { "type": "text", "id": "parent", "label": "Parent Answer Title(s) (leave blank for step 1)", "info": "Separate multiple titles with |" },
         { "type": "text", "id": "title", "label": "Answer Text" },
         { "type": "textarea", "id": "description", "label": "Description" },
         { "type": "text", "id": "value", "label": "Answer Value" },


### PR DESCRIPTION
## Summary
- allow specifying multiple parent answers by separating with `|`
- document multi-parent capability in block schema

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f4c413898833299601cea38726546