### PR TITLE
feat: add optional "Why we ask" field

### DIFF
--- a/sections/cancer-question.liquid
+++ b/sections/cancer-question.liquid
@@ -12,6 +12,7 @@
         <div class="cancer-question__text">
           <h2>{{ section.settings.heading }}</h2>
           <p>{{ section.settings.subheading }}</p>
+          <p class="why-we-ask" style="display:none;"></p>
         </div>
 
         <div class="cancer-question__blocks" id="quiz-container">
@@ -112,6 +113,7 @@
           description: {{ block.settings.description | json }},
           heading: {{ block.settings.step_heading | json }},
           subheading: {{ block.settings.step_subheading | json }},
+          why: {{ block.settings.step_why | json }},
           value: {{ block.settings.value | json }},
           url: {{ block.settings.url | json }}
         }{% unless forloop.last %},{% endunless %}
@@ -127,12 +129,45 @@
       }
     });
 
-    var resultMap = {
+    var resultMappings = [
       {% assign result_blocks = section.blocks | where: 'type', 'result' %}
       {% for block in result_blocks %}
-        {{ block.settings.combination | json }}: {{ block.settings.url | json }}{% unless forloop.last %},{% endunless %}
+        { combo: {{ block.settings.combination | json }}, url: {{ block.settings.url | json }} }{% unless forloop.last %},{% endunless %}
       {% endfor %}
-    };
+    ];
+
+    resultMappings = resultMappings.map(function (r) {
+      var map = {};
+      r.combo.split('|').forEach(function (part, index) {
+        var step, value;
+        if (part.indexOf('=') > -1) {
+          var pieces = part.split('=');
+          step = pieces[0].trim();
+          value = pieces[1].trim();
+        } else {
+          step = (index + 1).toString();
+          value = part.trim();
+        }
+        map[step] = value;
+      });
+      r.map = map;
+      return r;
+    });
+
+    function checkResult(ans) {
+      for (var i = 0; i < resultMappings.length; i++) {
+        var rm = resultMappings[i];
+        var match = true;
+        for (var step in rm.map) {
+          if (ans[step] !== rm.map[step]) {
+            match = false;
+            break;
+          }
+        }
+        if (match) return rm.url;
+      }
+      return null;
+    }
 
     var container = document.getElementById('quiz-container');
     var currentStep = 1;
@@ -147,22 +182,27 @@
       });
 
       if (!choices.length) {
-        var keyParts = [];
-        for (var i = 1; i < step; i++) {
-          keyParts.push(answers[i]);
-        }
-        var finalUrl = resultMap[keyParts.join('|')] || lastUrl;
+        var finalUrl = checkResult(answers) || lastUrl;
         if (finalUrl) {
           window.location.href = finalUrl;
         }
         return;
       }
 
-      // Dynamic heading and subheading update
+      // Dynamic heading, subheading, and "why we ask" update
       var headingEl = document.querySelector('.cancer-question__text h2');
       var subheadingEl = document.querySelector('.cancer-question__text p');
+      var whyEl = document.querySelector('.cancer-question__text .why-we-ask');
       if (choices[0].heading && headingEl) headingEl.textContent = choices[0].heading;
       if (choices[0].subheading && subheadingEl) subheadingEl.textContent = choices[0].subheading;
+      if (whyEl) {
+        if (choices[0].why) {
+          whyEl.innerHTML = '<strong>Why we ask:</strong> ' + choices[0].why;
+          whyEl.style.display = 'block';
+        } else {
+          whyEl.style.display = 'none';
+        }
+      }
 
       choices.forEach(function (b) {
         var card = document.createElement('div');
@@ -186,11 +226,7 @@
       var card = e.target.closest('.cancer-question__block');
       if (!card) return;
       answers[currentStep] = card.dataset.value;
-      var keyParts = [];
-      for (var i = 1; i <= currentStep; i++) {
-        keyParts.push(answers[i]);
-      }
-      var partialUrl = resultMap[keyParts.join('|')];
+      var partialUrl = checkResult(answers);
       if (partialUrl) {
         window.location.href = partialUrl;
         return;
@@ -236,14 +272,15 @@
         { "type": "text", "id": "value", "label": "Answer Value" },
         { "type": "url", "id": "url", "label": "URL to Link To (optional)" },
         { "type": "text", "id": "step_heading", "label": "Step Heading (optional)" },
-        { "type": "text", "id": "step_subheading", "label": "Step Subheading (optional)" }
+        { "type": "text", "id": "step_subheading", "label": "Step Subheading (optional)" },
+        { "type": "textarea", "id": "step_why", "label": "Why we ask (optional)" }
       ]
     },
     {
       "type": "result",
       "name": "Result Mapping",
       "settings": [
-        { "type": "text", "id": "combination", "label": "Answer Combination (value1|value2|...)" },
+        { "type": "text", "id": "combination", "label": "Answer Combination (value1|value2|... or step=value|step=value)" },
         { "type": "url", "id": "url", "label": "Result URL" }
       ]
     }

--- a/templates/page.breast-question.json
+++ b/templates/page.breast-question.json
@@ -137,7 +137,7 @@
             "parent": "",
             "title": "Estrogen Positive (ER+) ",
             "description": "",
-            "value": "erp",
+            "value": "",
             "url": "",
             "step_heading": "",
             "step_subheading": "",

--- a/templates/page.breast-question.json
+++ b/templates/page.breast-question.json
@@ -407,7 +407,7 @@
             "url": "",
             "step_heading": "Are you postmenopausal?",
             "step_subheading": "You are considered postmenopausal if you haven’t had a menstrual period for 12 months or if your medical team has told you that you are.",
-            "step_why": ""
+            "step_why": "Once your ovaries stop producing estrogen, your body’s nutritional needs—and how it interacts with certain natural ingredients or cancer medications—shift. Our oncologist-led team took this into account when formulating each SurvivorRx routine, because one size does not fit all."
           }
         },
         "question_dXLqYM": {

--- a/templates/page.breast-question.json
+++ b/templates/page.breast-question.json
@@ -27,106 +27,6 @@
         "padding_bottom": 50
       }
     },
-    "cancer_question_6xCDwY": {
-      "type": "cancer-question",
-      "disabled": true,
-      "settings": {
-        "bg_color": "#fcf4f6",
-        "padding_top": 20,
-        "padding_bottom": 20,
-        "image": "shopify://shop_images/Breast_Landing_Page.jpg",
-        "heading": "Which type of breast cancer did you survive?",
-        "subheading": "Your treatment was breast cancer specific—now your supplements can be too."
-      }
-    },
-    "cancer_question_4TnRXe": {
-      "type": "cancer-question",
-      "blocks": {
-        "result_Kp43Qj": {
-          "type": "result",
-          "settings": {
-            "combination": "ERS|yes|IV",
-            "url": ""
-          }
-        },
-        "result_8fFta8": {
-          "type": "result",
-          "settings": {
-            "combination": "ERS|no|cdk",
-            "url": ""
-          }
-        },
-        "result_JxHqNd": {
-          "type": "result",
-          "settings": {
-            "combination": "",
-            "url": ""
-          }
-        },
-        "result_DgcH39": {
-          "type": "result",
-          "settings": {
-            "combination": "",
-            "url": ""
-          }
-        },
-        "result_cLhDWt": {
-          "type": "result",
-          "settings": {
-            "combination": "",
-            "url": ""
-          }
-        },
-        "result_QbF4L7": {
-          "type": "result",
-          "settings": {
-            "combination": "",
-            "url": ""
-          }
-        },
-        "result_DWpxWR": {
-          "type": "result",
-          "settings": {
-            "combination": "",
-            "url": ""
-          }
-        },
-        "question_WyFrzL": {
-          "type": "question",
-          "settings": {
-            "step": 1,
-            "parent": "",
-            "title": "",
-            "description": "",
-            "value": "",
-            "url": "",
-            "step_heading": "",
-            "step_subheading": "",
-            "step_why": ""
-          }
-        }
-      },
-      "block_order": [
-        "result_Kp43Qj",
-        "result_8fFta8",
-        "result_JxHqNd",
-        "result_DgcH39",
-        "result_cLhDWt",
-        "result_QbF4L7",
-        "result_DWpxWR",
-        "question_WyFrzL"
-      ],
-      "disabled": true,
-      "name": "Cancer Question",
-      "settings": {
-        "bg_color": "#f9dee5",
-        "padding_top": 20,
-        "padding_bottom": 20,
-        "image": "shopify://shop_images/Breast_Landing_Page_f609d583-07ee-4809-b645-00913d108fad.jpg",
-        "heading": "Which type of breast cancer did you survive?",
-        "subheading": "Your treatment was breast cancer specific—now your supplements can be too."
-      }
-    },
     "cancer_question_9Xetih": {
       "type": "cancer-question",
       "blocks": {
@@ -621,8 +521,6 @@
   },
   "order": [
     "main",
-    "cancer_question_6xCDwY",
-    "cancer_question_4TnRXe",
     "cancer_question_9Xetih"
   ]
 }

--- a/templates/page.breast-question.json
+++ b/templates/page.breast-question.json
@@ -281,7 +281,7 @@
             "url": "",
             "step_heading": "Question 3: Are you currently taking any of the following medications?",
             "step_subheading": "I’m currently on:",
-            "step_why": ""
+            "step_why": "Understanding your HER2 status helps us provide more personalized support and ensure the safest approach to your wellness."
           }
         },
         "question_D6WGJJ": {

--- a/templates/page.breast-question.json
+++ b/templates/page.breast-question.json
@@ -341,7 +341,7 @@
         "result_QmcnDe": {
           "type": "result",
           "settings": {
-            "combination": "HER2P|SERMs",
+            "combination": "2=HER2P|3=SERMs",
             "url": "https://survivorrx.com/products/wellsurvivor-breast-br-10"
           }
         },

--- a/templates/page.breast-question.json
+++ b/templates/page.breast-question.json
@@ -141,7 +141,7 @@
             "url": "",
             "step_heading": "",
             "step_subheading": "",
-            "step_why": "nm"
+            "step_why": "Your breast cancer subtype, including hormone receptor status and other markers, can significantly impact which nutrients are safe and beneficial after treatment. By understanding these details, we can avoid ingredients that may interfere with your past or ongoing treatment, make smarter and safer formulation decisions, and help fill nutritional gaps that are common post-treatment."
           }
         },
         "question_khEiwH": {

--- a/templates/page.breast-question.json
+++ b/templates/page.breast-question.json
@@ -101,7 +101,8 @@
             "value": "",
             "url": "",
             "step_heading": "",
-            "step_subheading": ""
+            "step_subheading": "",
+            "step_why": ""
           }
         }
       },
@@ -139,7 +140,8 @@
             "value": "erp",
             "url": "",
             "step_heading": "",
-            "step_subheading": ""
+            "step_subheading": "",
+            "step_why": "nm"
           }
         },
         "question_khEiwH": {
@@ -152,7 +154,8 @@
             "value": "era",
             "url": "",
             "step_heading": "",
-            "step_subheading": ""
+            "step_subheading": "",
+            "step_why": ""
           }
         },
         "question_MAWC3w": {
@@ -165,7 +168,8 @@
             "value": "erpdcis",
             "url": "",
             "step_heading": "",
-            "step_subheading": ""
+            "step_subheading": "",
+            "step_why": ""
           }
         },
         "question_kmpQk6": {
@@ -178,7 +182,8 @@
             "value": "",
             "url": "https://survivorrx.com/products/wellsurvivor-breast-br-6",
             "step_heading": "",
-            "step_subheading": ""
+            "step_subheading": "",
+            "step_why": ""
           }
         },
         "question_crbwbY": {
@@ -191,7 +196,8 @@
             "value": "multiplebr",
             "url": "",
             "step_heading": "",
-            "step_subheading": ""
+            "step_subheading": "",
+            "step_why": ""
           }
         },
         "question_FLtyAF": {
@@ -204,7 +210,8 @@
             "value": "",
             "url": "https://survivorrx.com/pages/quiz",
             "step_heading": "",
-            "step_subheading": ""
+            "step_subheading": "",
+            "step_why": ""
           }
         },
         "question_xKDnkp": {
@@ -217,7 +224,8 @@
             "value": "HER2P",
             "url": "",
             "step_heading": "What is your HER2 status?",
-            "step_subheading": ""
+            "step_subheading": "",
+            "step_why": ""
           }
         },
         "question_XRwM99": {
@@ -230,7 +238,8 @@
             "value": "TPBC",
             "url": "",
             "step_heading": "",
-            "step_subheading": ""
+            "step_subheading": "",
+            "step_why": ""
           }
         },
         "question_bkxNam": {
@@ -243,7 +252,8 @@
             "value": "HER2N",
             "url": "",
             "step_heading": "",
-            "step_subheading": ""
+            "step_subheading": "",
+            "step_why": ""
           }
         },
         "question_bdmFqq": {
@@ -256,7 +266,8 @@
             "value": "TNBC",
             "url": "",
             "step_heading": "",
-            "step_subheading": ""
+            "step_subheading": "",
+            "step_why": ""
           }
         },
         "question_cRNwVV": {
@@ -269,7 +280,8 @@
             "value": "ncm",
             "url": "",
             "step_heading": "Question 3: Are you currently taking any of the following medications?",
-            "step_subheading": "I’m currently on:"
+            "step_subheading": "I’m currently on:",
+            "step_why": ""
           }
         },
         "question_D6WGJJ": {
@@ -282,7 +294,8 @@
             "value": "SERMs",
             "url": "",
             "step_heading": "",
-            "step_subheading": ""
+            "step_subheading": "",
+            "step_why": ""
           }
         },
         "question_wWxnj9": {
@@ -295,7 +308,8 @@
             "value": "AIs",
             "url": "",
             "step_heading": "",
-            "step_subheading": ""
+            "step_subheading": "",
+            "step_why": ""
           }
         },
         "question_V4dVte": {
@@ -308,7 +322,8 @@
             "value": "SERDs",
             "url": "",
             "step_heading": "",
-            "step_subheading": ""
+            "step_subheading": "",
+            "step_why": ""
           }
         },
         "question_xgpB8i": {
@@ -321,7 +336,8 @@
             "value": "4/6SERMs",
             "url": "",
             "step_heading": "",
-            "step_subheading": ""
+            "step_subheading": "",
+            "step_why": ""
           }
         },
         "question_7z4ryY": {
@@ -334,7 +350,8 @@
             "value": "4/6AIs",
             "url": "",
             "step_heading": "",
-            "step_subheading": ""
+            "step_subheading": "",
+            "step_why": ""
           }
         },
         "question_mLXbHB": {
@@ -347,7 +364,8 @@
             "value": "4/6SERDs",
             "url": "",
             "step_heading": "",
-            "step_subheading": ""
+            "step_subheading": "",
+            "step_why": ""
           }
         },
         "question_MmWX9r": {
@@ -360,7 +378,8 @@
             "value": "",
             "url": "shopify://pages/contact-us",
             "step_heading": "",
-            "step_subheading": ""
+            "step_subheading": "",
+            "step_why": ""
           }
         },
         "question_pqrqqq": {
@@ -373,7 +392,8 @@
             "value": "",
             "url": "https://survivorrx.com/products/wellsurvivor-breast-br-8",
             "step_heading": "",
-            "step_subheading": ""
+            "step_subheading": "",
+            "step_why": ""
           }
         },
         "question_t3BJTQ": {
@@ -386,7 +406,8 @@
             "value": "",
             "url": "",
             "step_heading": "Are you postmenopausal?",
-            "step_subheading": "You are considered postmenopausal if you haven’t had a menstrual period for 12 months or if your medical team has told you that you are."
+            "step_subheading": "You are considered postmenopausal if you haven’t had a menstrual period for 12 months or if your medical team has told you that you are.",
+            "step_why": ""
           }
         },
         "question_dXLqYM": {
@@ -399,7 +420,8 @@
             "value": "",
             "url": "",
             "step_heading": "Are you postmenopausal?",
-            "step_subheading": "You are considered postmenopausal if you haven’t had a menstrual period for 12 months or if your medical team has told you that you are."
+            "step_subheading": "You are considered postmenopausal if you haven’t had a menstrual period for 12 months or if your medical team has told you that you are.",
+            "step_why": ""
           }
         },
         "result_HFxW63": {

--- a/templates/page.breast-question.json
+++ b/templates/page.breast-question.json
@@ -348,119 +348,119 @@
         "result_MiCbFB": {
           "type": "result",
           "settings": {
-            "combination": "HER2N|SERMs",
+            "combination": "2=HER2N|3=SERMs",
             "url": "https://survivorrx.com/products/wellsurvivor-breast-br-8"
           }
         },
         "result_8fhTkM": {
           "type": "result",
           "settings": {
-            "combination": "TPBC|SERMs",
+            "combination": "2=TPBC|3=SERMs",
             "url": "https://survivorrx.com/products/wellsurvivor-breast-br-10"
           }
         },
         "result_M3Qk3t": {
           "type": "result",
           "settings": {
-            "combination": "HER2N|AIs",
+            "combination": "2=HER2N|3=AIs",
             "url": "https://survivorrx.com/products/wellsurvivor-breast-br-8"
           }
         },
         "result_yMFAgi": {
           "type": "result",
           "settings": {
-            "combination": "HER2P|AIs",
+            "combination": "2=HER2P|3=AIs",
             "url": "https://survivorrx.com/products/wellsurvivor-breast-br-12"
           }
         },
         "result_jdNnRQ": {
           "type": "result",
           "settings": {
-            "combination": "TPBC|AIs",
+            "combination": "2=TPBC|3=AIs",
             "url": "https://survivorrx.com/products/wellsurvivor-breast-br-12"
           }
         },
         "result_gNFpFH": {
           "type": "result",
           "settings": {
-            "combination": "HER2N|SERDs",
+            "combination": "2=HER2N|3=SERDs",
             "url": "https://survivorrx.com/products/wellsurvivor-breast-br-8"
           }
         },
         "result_z9Fnmk": {
           "type": "result",
           "settings": {
-            "combination": "HER2P|SERDs",
+            "combination": "2=HER2P|3=SERDs",
             "url": "https://survivorrx.com/products/wellsurvivor-breast-br-12"
           }
         },
         "result_km6caE": {
           "type": "result",
           "settings": {
-            "combination": "TPBC|SERDs",
+            "combination": "2=TPBC|3=SERDs",
             "url": "https://survivorrx.com/products/wellsurvivor-breast-br-12"
           }
         },
         "result_mEjLGF": {
           "type": "result",
           "settings": {
-            "combination": "HER2N|4/6SERMs",
+            "combination": "2=HER2N|3=4/6SERMs",
             "url": "https://survivorrx.com/products/wellsurvivor-breast-br-9"
           }
         },
         "result_QaHVfK": {
           "type": "result",
           "settings": {
-            "combination": "HER2P|4/6SERMs",
+            "combination": "2=HER2P|3=4/6SERMs",
             "url": "https://survivorrx.com/products/wellsurvivor-breast-br-15"
           }
         },
         "result_E8zBiV": {
           "type": "result",
           "settings": {
-            "combination": "TPBC|4/6SERMs",
+            "combination": "2=TPBC|3=4/6SERMs",
             "url": "https://survivorrx.com/products/wellsurvivor-breast-br-15"
           }
         },
         "result_pQK9d7": {
           "type": "result",
           "settings": {
-            "combination": "HER2N|4/6AIs",
+            "combination": "2=HER2N|3=4/6AIs",
             "url": "https://survivorrx.com/products/wellsurvivor-breast-br-13"
           }
         },
         "result_fA4Q9D": {
           "type": "result",
           "settings": {
-            "combination": "HER2P|4/6AIs",
+            "combination": "2=HER2P|3=4/6AIs",
             "url": "https://survivorrx.com/products/wellsurvivor-breast-br-14"
           }
         },
         "result_YawKnq": {
           "type": "result",
           "settings": {
-            "combination": "TPBC|4/6AIs",
+            "combination": "2=TPBC|3=4/6AIs",
             "url": "https://survivorrx.com/products/wellsurvivor-breast-br-14"
           }
         },
         "result_7VJyD7": {
           "type": "result",
           "settings": {
-            "combination": "HER2N|4/6SERDs",
+            "combination": "2=HER2N|3=4/6SERDs",
             "url": "https://survivorrx.com/products/wellsurvivor-breast-br-13"
           }
         },
         "result_hD48aQ": {
           "type": "result",
           "settings": {
-            "combination": "HER2P|4/6SERDs",
+            "combination": "2=HER2P|3=4/6SERDs",
             "url": "https://survivorrx.com/products/wellsurvivor-breast-br-14"
           }
         },
         "result_q69aRy": {
           "type": "result",
           "settings": {
-            "combination": "TPBC|4/6SERDs",
+            "combination": "2=TPBC|3=4/6SERDs",
             "url": "https://survivorrx.com/products/wellsurvivor-breast-br-14"
           }
         }


### PR DESCRIPTION
## Summary
- allow quiz steps to include an optional "Why we ask" explanation beneath the subheading
- expose a new `step_why` textarea in answer option blocks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5364ba240833294f74afefc3a8cde