### PR TITLE
Prevent early redirect in cancer quiz

### DIFF
--- a/sections/cancer-question.liquid
+++ b/sections/cancer-question.liquid
@@ -226,12 +226,9 @@
       var card = e.target.closest('.cancer-question__block');
       if (!card) return;
       answers[currentStep] = card.dataset.value;
-      var partialUrl = checkResult(answers);
-      if (partialUrl) {
-        window.location.href = partialUrl;
-        return;
+      if (card.dataset.url) {
+        lastUrl = card.dataset.url;
       }
-      lastUrl = card.dataset.url;
       currentStep++;
       render(currentStep, card.dataset.title);
     });


### PR DESCRIPTION
## Summary
- stop cancer quiz from redirecting after the first question unless a URL is provided

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a55bb1559c83329b31c352c6e44a78