### PR TITLE
Fix premature redirect on first quiz question

### DIFF
--- a/sections/cancer-question.liquid
+++ b/sections/cancer-question.liquid
@@ -210,8 +210,11 @@
     });
 
     function checkResult(ans) {
+      var ansKeys = Object.keys(ans);
       for (var i = 0; i < resultMappings.length; i++) {
         var rm = resultMappings[i];
+        var rmKeys = Object.keys(rm.map);
+        if (ansKeys.length !== rmKeys.length) continue;
         var match = true;
         for (var step in rm.map) {
           if (ans[step] !== rm.map[step]) {
@@ -299,11 +302,6 @@
       var card = e.target.closest('.cancer-question__block');
       if (!card) return;
       answers[currentStep] = card.dataset.value;
-      var partialUrl = checkResult(answers);
-      if (partialUrl) {
-        window.location.href = partialUrl;
-        return;
-      }
       lastUrl = card.dataset.url;
       currentStep++;
       render(currentStep, card.dataset.title);


### PR DESCRIPTION
## Summary
- ensure result mappings only trigger when all steps are answered
- remove early redirect check so first question without link does not navigate away

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afc6aad52c83328ec72f7a2e3e7ae6